### PR TITLE
Code style docs

### DIFF
--- a/_includes/nav-bar.html
+++ b/_includes/nav-bar.html
@@ -16,7 +16,7 @@
     <!-- Collect the nav links, forms, and other content for toggling -->
     <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
       <ul class="nav navbar-nav">
-        <li class="active"><a href="/">Home <span class="sr-only">(current)</span></a></li>
+        <li><a href="/">Home <span class="sr-only">(current)</span></a></li>
         <li><a href="/install/">Install</a></li>
 
 
@@ -49,7 +49,16 @@
         </li>
         <li><a href="/media/">Media</a></li>
         <li><a href="/support/">Support</a></li>
-        <li><a href="/documentation/contributing/">Contribute</a></li>
+
+        <li class="dropdown">
+          <a href="/documentation/contributing" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
+                Contribute <span class="caret"></span></a>
+          <ul class="dropdown-menu">
+            <li><a href="/documentation/contributing">Contribute</a></li>
+            <li role='separator' class='divider'>
+            <li><a href="/documentation/contributing/code.html">Code Style</a></li>
+          </ul>
+        </li>
         <li><a href="/blog/">Blog</a></li>
       </ul>
     </div><!-- /.navbar-collapse -->

--- a/documentation/contributing/code.markdown
+++ b/documentation/contributing/code.markdown
@@ -1,0 +1,20 @@
+# MoveIt! Code Style
+
+We use the [ROS C++ Style guide](http://wiki.ros.org/CppStyleGuide) for all C++ development and the [ROS Python Style guide](http://wiki.ros.org/PyStyleGuide) for Python.
+
+To ease your development, we recommend the automated code formatter ``clang-format`` with a ROS configuration found [here](https://github.com/davetcoleman/roscpp_code_format)
+
+In addition MoveIt! has some extra style preferences:
+
+## C++
+
+ - As of ROS Kinetic we use C++11
+ - Use the C++ standard library (``std::``) whenever possible
+ - Avoid C-style functions such as ``FLT_EPSILON`` - instead use ``std::numeric_limits<double>::epsilon()``
+ - Boost is an encouraged library when functionality is not available in the standard library
+ - Prefer full variable names over short acryonms - e.g. ``robot_state_`` over ``rs_``
+ - Deprecate functions using [MOVEIT_DEPRECATED](https://github.com/ros-planning/moveit_core/blob/kinetic-devel/macros/include/moveit/macros/deprecation.h) in deprecation.h
+
+## ROS
+
+ - The ROS logging functionality is utilized and namespacing your logs are recommended, i.e. ``ROS_INFO_NAMED("planning_scene", "Starting listener")``

--- a/documentation/contributing/index.markdown
+++ b/documentation/contributing/index.markdown
@@ -29,6 +29,8 @@ i.e. [pr2_moveit_tutorials](https://github.com/ros-planning/moveit_pr2/tree/indi
 
 For deploying documentation changes to the web, [Section 3 of rosdoc_lite wiki](http://wiki.ros.org/rosdoc_lite) says that "rosdoc_lite is automatically run for packages in repositories that have rosinstall files listed in the rosdistro repository." This is done about once every 24 hours, [overnight](http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation).
 
+Note that ``README.md`` files that are popular on Github should be mainly used to redirect users to the corresponding Sphinx files and website pages.
+
 ### moveit.ros.org
 
 Once you have created new Sphinx documentation, you'll need to create links to it from the main moveit.ros.org website so that other users can find it. Additionally, some higher level documentation can be found directly on this website, so you'll need to edit it there as well.
@@ -50,6 +52,8 @@ Bugs should be reported to the Github issues page of the appropriate repo. Pleas
 ### Pull Requests
 
 Our policy for contributing changes to the code base is that no one, not even the maintainers, should commit directly to the repo. Rather, you should create a feature branch on your own fork of the project then create a PR when it's ready to be reviewed by someone else. All changes should be merged by someone other than the author of the PR. The only exceptions to this rule is when cherry-picking commits from older branches (previous ROS releases) to newer branches, and release-related commits (CHANGELOGS, tags).
+
+See [MoveIt! Code Style](code.html) for details on how to format your pull requests.
 
 ## Reviewing Pull Requests
 

--- a/documentation/faqs/index.markdown
+++ b/documentation/faqs/index.markdown
@@ -151,14 +151,6 @@ _How do I join the moveit-users mailing list?_
 ## Code
 
 
-_Is there a style guide for MoveIt!?_
-
-
-
-
-  * We use the [ROS Style guide](http://wiki.ros.org/CppStyleGuide) for all development.
-
-
 _Where can I find the changelogs for MoveIt!?_
 
 


### PR DESCRIPTION
Starting point for documenting code style for MoveIt!, based on MoveIt!'s current style in the codebase. Useful to new users attempting to create pull requests.

Converts Contribute button in nav bar to drop down.

Also fixes bug in navigation bar where Home is always marked as the active page, even when its not